### PR TITLE
feat: support UUID returned by the API

### DIFF
--- a/packages/api-client/src/api/getCart/index.ts
+++ b/packages/api-client/src/api/getCart/index.ts
@@ -4,7 +4,7 @@ import { deserializeCart } from '../serializers/cart';
 import { cartParams } from '../common/cart';
 
 const emptyCart: Cart = {
-  _id: 'uuid',
+  _id: 'empty_cart',
   email: '',
   number: '',
   state: 'cart',

--- a/packages/api-client/src/api/getCart/index.ts
+++ b/packages/api-client/src/api/getCart/index.ts
@@ -4,7 +4,7 @@ import { deserializeCart } from '../serializers/cart';
 import { cartParams } from '../common/cart';
 
 const emptyCart: Cart = {
-  _id: 0,
+  _id: 'uuid',
   email: '',
   number: '',
   state: 'cart',

--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -41,8 +41,8 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
   const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl) : '';
 
   return {
-    id: parseInt(lineItem.id, 10),
-    _variantId: parseInt(variant.id, 10),
+    id: lineItem.id,
+    _variantId: variant.id,
     _description: '',
     _categoriesRef: [],
     name: lineItem.attributes.name,
@@ -77,7 +77,7 @@ const findAddress = (data, included) => {
 };
 
 export const deserializeCart = (apiCart: OrderAttr, included: any[], config: any): Cart => ({
-  _id: parseInt(apiCart.id, 10),
+  _id: apiCart.id,
   email: apiCart.attributes.email,
   number: apiCart.attributes.number,
   state: apiCart.attributes.state,

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -57,7 +57,7 @@ const deserializeImages = (included: JsonApiDocument[], documents: JsonApiDocume
 
   return sortedImageDocuments
     .map(image => ({
-      id: parseInt(image.id, 10),
+      id: image.id,
       styles: image.attributes.styles.map(style => ({
         url: style.url,
         width: parseInt(style.width, 10),
@@ -79,7 +79,7 @@ const deserializeOptionTypes = (included, product): OptionType[] => {
   const optionTypes = extractRelationships(included, 'option_type', 'option_types', product);
 
   return optionTypes.map(optionType => ({
-    id: parseInt(optionType.id, 10),
+    id: optionType.id,
     type: optionType.type,
     name: optionType.attributes.name,
     position: optionType.attributes.position,
@@ -91,12 +91,12 @@ const deserializeOptionValues = (included, variant): OptionValue[] => {
   const optionValues = extractRelationships(included, 'option_value', 'option_values', variant);
 
   return optionValues.map(optionValue => ({
-    id: parseInt(optionValue.id, 10),
+    id: optionValue.id,
     type: optionValue.attributes.type,
     name: optionValue.attributes.name,
     position: optionValue.attributes.position,
     presentation: optionValue.attributes.presentation,
-    optionTypeId: parseInt(optionValue.relationships.option_type.data.id, 10)
+    optionTypeId: optionValue.relationships.option_type.data.id
   }));
 };
 

--- a/packages/api-client/src/types/cart.ts
+++ b/packages/api-client/src/types/cart.ts
@@ -2,7 +2,7 @@ import { Address } from './checkout';
 
 export type LineItem = {
   id: string;
-  _variantId: number;
+  _variantId: string;
   _description: string;
   _categoriesRef: string[];
   name: string;

--- a/packages/api-client/src/types/cart.ts
+++ b/packages/api-client/src/types/cart.ts
@@ -1,7 +1,7 @@
 import { Address } from './checkout';
 
 export type LineItem = {
-  id: number;
+  id: string;
   _variantId: number;
   _description: string;
   _categoriesRef: string[];
@@ -21,7 +21,7 @@ export type LineItem = {
 };
 
 export type Cart = {
-  _id: number;
+  _id: string;
   email: string;
   number: string;
   state: string;

--- a/packages/api-client/src/types/category.ts
+++ b/packages/api-client/src/types/category.ts
@@ -1,5 +1,5 @@
 export type Category = {
-  id: number;
+  id: string;
   name: string;
   slug: string;
   items?: Category[];

--- a/packages/api-client/src/types/product.ts
+++ b/packages/api-client/src/types/product.ts
@@ -1,16 +1,16 @@
 import { AgnosticBreadcrumb, AgnosticGroupedFacet } from '@vue-storefront/core';
 
 export type OptionValue = {
-  id: number;
+  id: string;
   type: string;
   name: string;
   position: number;
   presentation: string;
-  optionTypeId: number;
+  optionTypeId: string;
 };
 
 export type OptionType = {
-  id: number;
+  id: string;
   type: string;
   name: string;
   position: number;
@@ -24,7 +24,7 @@ export type ImageStyle = {
 };
 
 export type Image = {
-  id: number;
+  id: string;
   styles: ImageStyle[];
 };
 
@@ -34,9 +34,9 @@ export type Property = {
 };
 
 export type ProductVariant = {
-  _id: number;
-  _productId: number;
-  _variantId: number;
+  _id: string;
+  _productId: string;
+  _variantId: string;
   _description: string;
   _categoriesRef: string[];
   name: string;

--- a/packages/composables/src/useMakeOrder/index.ts
+++ b/packages/composables/src/useMakeOrder/index.ts
@@ -9,7 +9,7 @@ const factoryParams = {
 
   make: async (context: Context): Promise<Order> => {
     await context.$spree.api.makeOrder();
-    context.setCart({_id: 0, lineItems: []});
+    context.setCart({_id: 'empty_cart', lineItems: []});
     return undefined;
   }
 };

--- a/packages/composables/src/useUser/index.ts
+++ b/packages/composables/src/useUser/index.ts
@@ -24,7 +24,7 @@ const params: UseUserFactoryParams<User, any, any> = {
 
   logOut: async (context: Context) => {
     await context.$spree.api.logOut();
-    context.setCart({_id: 0, lineItems: []});
+    context.setCart({_id: 'empty_cart', lineItems: []});
   },
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -19,9 +19,9 @@ const getOptionTypeFiltersFromURL = (): SearchParamsOptionTypeFilter[] => {
       const optionTypeName = key.substring(2);
 
       if (Array.isArray(value)) {
-        return [...filters, ...value.map(e => ({ optionTypeName, optionValueId: parseInt(e, 10) }))];
+        return [...filters, ...value.map(e => ({ optionTypeName, optionValueId: e }))];
       } else {
-        return [...filters, { optionTypeName, optionValueId: parseInt(value, 10) }];
+        return [...filters, { optionTypeName, optionValueId: value }];
       }
     }, []);
 };

--- a/packages/theme/pages/Checkout/ThankYou.vue
+++ b/packages/theme/pages/Checkout/ThankYou.vue
@@ -165,7 +165,7 @@ export default {
 
       if (orderNumber.value === cart.value.number) {
         // When Stripe's callback redirects us directly to thank you page, we should clear cart here
-        setCart({ _id: 0, lineItems: [] });
+        setCart({ _id: 'empty_cart', lineItems: [] });
         $spree.api.removeCartToken();
       }
     });


### PR DESCRIPTION
By default in our integration the IDs received and sent to the API are incremented Integers. This change is needed so we can handle UUIDs that are held in the Vendo's API.

## Description
This change introduces IDs as strings support for Vendo API's UUIDs database scheme.

## How Has This Been Tested?
This was tested in our test environment that's integrated with Vendo's test env.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
