### PR TITLE
feat: support full image urls

### DIFF
--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -9,7 +9,7 @@ const findAttachment = (attachments: any[], id: string, type: string) => {
   return attachments.find(e => e.id === id && e.type === type);
 };
 
-const formatImageUrl = (styles: any[], backendUrl: string): string => {
+const formatImageUrl = (styles: any[], backendUrl: string, useFullImageUrls: boolean): string => {
   let coverImage = styles[0];
 
   styles.forEach(img => {
@@ -17,7 +17,7 @@ const formatImageUrl = (styles: any[], backendUrl: string): string => {
       coverImage = img;
   });
 
-  return backendUrl.concat(coverImage.url);
+  return useFullImageUrls ? coverImage.url : backendUrl.concat(coverImage.url);
 };
 
 const formatOptions = (optionsText: string) => {
@@ -38,7 +38,7 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
   const imagesData = variantImagesData.length > 0 ? variantImagesData : productImagesData;
   const image = findAttachment(attachments, imagesData[0]?.id, 'image');
 
-  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl) : '';
+  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl, config.useFullImageUrls) : '';
 
   return {
     id: parseInt(lineItem.id, 10),

--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -9,7 +9,7 @@ const findAttachment = (attachments: any[], id: string, type: string) => {
   return attachments.find(e => e.id === id && e.type === type);
 };
 
-const formatImageUrl = (styles: any[], backendUrl: string): string => {
+const formatImageUrl = (styles: any[], backendUrl: string, useFullImageUrls: boolean): string => {
   let coverImage = styles[0];
 
   styles.forEach(img => {
@@ -17,7 +17,7 @@ const formatImageUrl = (styles: any[], backendUrl: string): string => {
       coverImage = img;
   });
 
-  return backendUrl.concat(coverImage.url);
+  return useFullImageUrls ? coverImage.url : backendUrl.concat(coverImage.url);
 };
 
 const formatOptions = (optionsText: string) => {
@@ -38,7 +38,7 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
   const imagesData = variantImagesData.length > 0 ? variantImagesData : productImagesData;
   const image = findAttachment(attachments, imagesData[0]?.id, 'image');
 
-  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl) : '';
+  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl, config.useFullImageUrls) : '';
 
   return {
     id: lineItem.id,

--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -38,7 +38,7 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
   const imagesData = variantImagesData.length > 0 ? variantImagesData : productImagesData;
   const image = findAttachment(attachments, imagesData[0]?.id, 'image');
 
-  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl, config.useFullImageUrls) : '';
+  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl, config.spreeFeatures.useFullImageUrls) : '';
 
   return {
     id: lineItem.id,

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -229,7 +229,7 @@ const addHostToImage = (image, config: ApiConfig) => ({
     styles: image.attributes?.styles ? image.attributes.styles.map((style) => ({
       width: style.width,
       height: style.height,
-      url: config.useFullImageUrls ? style.url : config.backendUrl + style.url
+      url: config.spreeFeatures.useFullImageUrls ? style.url : config.backendUrl + style.url
     })) : []
   }
 });

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -229,7 +229,7 @@ const addHostToImage = (image, config: ApiConfig) => ({
     styles: image.attributes?.styles ? image.attributes.styles.map((style) => ({
       width: style.width,
       height: style.height,
-      url: config.backendUrl + style.url
+      url: config.useFullImageUrls ? style.url : config.backendUrl + style.url
     })) : []
   }
 });

--- a/packages/api-client/src/index.server.ts
+++ b/packages/api-client/src/index.server.ts
@@ -44,10 +44,10 @@ import vendoCreatePaymentIntent from './api/vendoCreatePaymentIntent';
 
 const defaultSettings = {
   backendUrl: 'https://demo.spreecommerce.org',
-  useFullImageUrls: false,
   spreeFeatures: {
     associateGuestCart: true,
-    fetchPrimaryVariant: true
+    fetchPrimaryVariant: true,
+    useFullImageUrls: false
   }
 };
 

--- a/packages/api-client/src/index.server.ts
+++ b/packages/api-client/src/index.server.ts
@@ -44,6 +44,7 @@ import vendoCreatePaymentIntent from './api/vendoCreatePaymentIntent';
 
 const defaultSettings = {
   backendUrl: 'https://demo.spreecommerce.org',
+  useFullImageUrls: false,
   spreeFeatures: {
     associateGuestCart: true,
     fetchPrimaryVariant: true

--- a/packages/api-client/src/types/index.ts
+++ b/packages/api-client/src/types/index.ts
@@ -45,10 +45,10 @@ export type ApiConfig = {
   auth: AuthIntegrationContext;
   internationalization: InternationalizationIntegrationContext;
   backendUrl: string;
-  useFullImageUrls: boolean,
   spreeFeatures: {
     associateGuestCart: boolean;
     fetchPrimaryVariant: boolean;
+    useFullImageUrls: boolean;
   }
 }
 

--- a/packages/api-client/src/types/index.ts
+++ b/packages/api-client/src/types/index.ts
@@ -45,6 +45,7 @@ export type ApiConfig = {
   auth: AuthIntegrationContext;
   internationalization: InternationalizationIntegrationContext;
   backendUrl: string;
+  useFullImageUrls: boolean,
   spreeFeatures: {
     associateGuestCart: boolean;
     fetchPrimaryVariant: boolean;

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -14,7 +14,6 @@ const defaultFeatures = {
     fetchPrimaryVariant: true,
     useFullImageUrls: true
   }
-
 };
 
 module.exports = {

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -8,7 +8,11 @@ const defaultFeatures = {
   spree43: {
     associateGuestCart: true,
     fetchPrimaryVariant: true
+  },
+  vendo: {
+    useFullImageUrls: true
   }
+
 };
 
 module.exports = {
@@ -17,7 +21,8 @@ module.exports = {
       location: '@vue-storefront/spree-api/server',
       configuration: {
         backendUrl: process.env.BACKEND_URL,
-        spreeFeatures: defaultFeatures.spree43
+        spreeFeatures: defaultFeatures.spree43,
+        ...defaultFeatures.vendo
       }
     }
   }

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -23,7 +23,7 @@ module.exports = {
       location: '@vue-storefront/spree-api/server',
       configuration: {
         backendUrl: process.env.BACKEND_URL,
-        spreeFeatures: defaultFeatures.vendo
+        spreeFeatures: defaultFeatures.spree43
       }
     }
   }

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -10,6 +10,8 @@ const defaultFeatures = {
     fetchPrimaryVariant: true
   },
   vendo: {
+    associateGuestCart: true,
+    fetchPrimaryVariant: true,
     useFullImageUrls: true
   }
 
@@ -21,8 +23,7 @@ module.exports = {
       location: '@vue-storefront/spree-api/server',
       configuration: {
         backendUrl: process.env.BACKEND_URL,
-        spreeFeatures: defaultFeatures.spree43,
-        ...defaultFeatures.vendo
+        spreeFeatures: defaultFeatures.vendo
       }
     }
   }


### PR DESCRIPTION
Vendo stores image links as absolute URLs instead of the relative ones like by default. We had to add support to that in the application.

## Description
This change introduces configurable option for switching between relative and absolute URLs for images.

## How Has This Been Tested?
This was tested in our test environment that's integrated with Vendo's test env.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
