### PR TITLE
feat: vendor and items information per shipping

### DIFF
--- a/packages/api-client/src/types/checkout.ts
+++ b/packages/api-client/src/types/checkout.ts
@@ -26,5 +26,14 @@ export type ShippingRate = {
 
 export type Shipment = {
   id: string;
+  stockLocationName: string,
+  lineItems: any[],
   availableShippingRates: ShippingRate[];
+}
+
+export type ShipmentLineItem = {
+  id: string;
+  name: string;
+  quantity: number;
+  total: number;
 }

--- a/packages/api-client/src/types/checkout.ts
+++ b/packages/api-client/src/types/checkout.ts
@@ -24,7 +24,17 @@ export type ShippingRate = {
   cost: string;
 };
 
+export type ShipmentLineItem = {
+  id: string;
+  name: string;
+  quantity: number;
+  total: number;
+}
+
 export type Shipment = {
   id: string;
+  stockLocationName: string,
+  lineItems: ShipmentLineItem[],
   availableShippingRates: ShippingRate[];
 }
+

--- a/packages/theme/components/Checkout/ShippingRatePicker.vue
+++ b/packages/theme/components/Checkout/ShippingRatePicker.vue
@@ -5,6 +5,20 @@
       :title="name"
       class="shipping-rate-picker__name sf-heading--left sf-heading--no-underline title"
     />
+    <SfTable class="shipping-table-spacer">
+      <SfTableHeading>
+        <SfTableHeader>Quantity</SfTableHeader>
+        <SfTableHeader>Name</SfTableHeader>
+        <SfTableHeader>Total</SfTableHeader>
+      </SfTableHeading>
+      <SfTableRow
+        v-for="item in shippingItems"
+        :key="item.id">
+        <SfTableData>{{item.quantity}}</SfTableData>
+        <SfTableData>{{item.name}}</SfTableData>
+        <SfTableData>{{item.total}}</SfTableData>
+      </SfTableRow>
+    </SfTable>
     <SfRadio
       v-e2e="'shipping-method'"
       v-for="rate in shippingRates"
@@ -26,7 +40,7 @@
 </template>
 
 <script>
-import { SfHeading, SfRadio, SfAlert } from '@storefront-ui/vue';
+import { SfHeading, SfRadio, SfAlert, SfTable } from '@storefront-ui/vue';
 import { checkoutGetters } from '@vue-storefront/spree';
 
 export default {
@@ -35,7 +49,8 @@ export default {
   components: {
     SfHeading,
     SfRadio,
-    SfAlert
+    SfAlert,
+    SfTable
   },
 
   props: {
@@ -62,6 +77,9 @@ export default {
     },
     areShippingRatesAvailable() {
       return this.shippingRates.length > 0;
+    },
+    shippingItems() {
+      return this.shipment?.lineItems;
     }
   },
 
@@ -77,5 +95,8 @@ export default {
 <style lang="scss" scoped>
 .shipping-rate-picker__name {
   margin-bottom: var(--spacer-sm);
+}
+.shipping-table-spacer {
+  margin-bottom: var(--spacer-xl);
 }
 </style>

--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -8,7 +8,7 @@
     <ShippingRatePicker
       v-for="(shipment, index) in shipments"
       :key="shipment.id"
-      :name="`Shipment #${index+1}`"
+      :name="`Shipment #${index+1} from ${shipment.stockLocationName}`"
       :shipment="shipment"
       class="vsf-shipping-provider__rate-picker"
       @change="shippingRateId => selectShippingRate(shipment.id, shippingRateId)"


### PR DESCRIPTION
Vendo introduces selecting different shipments for different Vendors. More info should be supplied to the user while completing the checout.

## Description
This change introduces listing the items per order and mentioning what vendor is suppling it.

## How Has This Been Tested?
This was tested in our test environment that's integrated with Vendo's test env.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
