### PR TITLE
Change repo url for cloning in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This integration is being developed and maintained by [Upside](https://upsidelab
 
 1. Clone this repository
 ```sh
-git clone https://github.com/vuestorefront/spree.git
+git clone https://github.com/vendo-dev/vuestorefront.git
 ```
 
 2. Install all required dependencies:


### PR DESCRIPTION
Currently, to setup Vendo VSF integration you need to clone `vendo-dev/vuestorefront`