### PR TITLE
fix: clearing vendor filters and page crashing after refresh

### DIFF
--- a/packages/composables/src/useFacet/index.ts
+++ b/packages/composables/src/useFacet/index.ts
@@ -14,7 +14,7 @@ const factoryParams = {
       vendorId = vendor?.id;
     } else {
       vendor = null;
-      vendorId = searchParams.vendorSlug ? [...searchParams.vendorSlug].join(',') : null;
+      vendorId = searchParams.vendorSlug && Array.isArray(searchParams.vendorSlug) ? [...searchParams.vendorSlug].join(',') : searchParams.vendorSlug;
     }
     const categories = await context.$spree.api.getCategory({ categorySlug: searchParams.categorySlug, vendorId: vendor?.id });
     const getProductsParams: GetProductsParams = {

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -57,7 +57,7 @@ const useUiHelpers = () => {
       vendorSlug = slugs[2];
     } else {
       categorySlug = slugs.slice(2).join('/');
-      vendorSlug = query.vendor !== undefined && query.vendor.length > 0 ? query.vendor : null;
+      vendorSlug = query.vendor && query.vendor.length > 0 ? query.vendor : null;
     }
     return {
       categorySlug,

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -83,7 +83,7 @@ const useUiHelpers = () => {
 
   const changeFilters = (filters) => {
     const queryWithoutFilters = Object.fromEntries(
-      Object.entries(query).filter(([key]) => !key.startsWith('o.') && !key.startsWith('p.') && key !== 'price')
+      Object.entries(query).filter(([key]) => !key.startsWith('o.') && !key.startsWith('p.') && key !== 'price' && key !== 'vendor')
     );
     instance.$router.push({ query: { ...queryWithoutFilters, ...filters }});
   };


### PR DESCRIPTION
## Description
Vendor filters were crashing when selecting one vendor and refreshing the page. Also clearing all filters was fixed.
## How Has This Been Tested?
This was tested in our test environment that's integrated with Vendo's test env.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
