### PR TITLE
feat: first and last name supplied during registeration

### DIFF
--- a/packages/api-client/src/api/registerUser/index.ts
+++ b/packages/api-client/src/api/registerUser/index.ts
@@ -1,9 +1,11 @@
 import { ApiContext } from '../../types';
 
-export default async function registerUser({ client }: ApiContext, { email, password }): Promise<void> {
+export default async function registerUser({ client }: ApiContext, { email, password, firstName, lastName }): Promise<void> {
   const userData = {
     email,
     password,
+    first_name: firstName,
+    last_name: lastName,
     passwordConfirmation: password
   };
 


### PR DESCRIPTION
## Description
Vendo requires first and last name arguments in the POST /account api call.
In existing Vuestorefront integration we skipped the first and last name in that call, so we need to support that.
## How Has This Been Tested?
This was tested in our test environment that's integrated with Vendo's test env.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
