### PR TITLE
fix: nested description rendering on vendor page fixed

### DIFF
--- a/packages/theme/pages/Vendor.vue
+++ b/packages/theme/pages/Vendor.vue
@@ -1,16 +1,16 @@
 <template>
   <div id="category">
     <div class="row">
-      <div class="column sf--column" style="height:200px" v-if="vendor.coverPhotoUrl">
-        <img :src="vendor.coverPhotoUrl" style="width: 100%; height: 100%; object-fit: cover">
+      <div class="column sf--column" v-if="vendor.coverPhotoUrl">
+        <img :src="vendor.coverPhotoUrl" style="width: 100%; height: 200px; object-fit: cover">
       </div>
-      <div class="column sf--column" style="height:200px">
+      <div class="column sf--column" >
         <SfHeading
                    :title="vendor.name"
                    :level="1"
                    class="sf-heading--no-underline sf-heading--left"
         />
-        <p v-html="vendor.aboutUs"></p>
+        <div v-html="vendor.aboutUs"/>
       </div>
     </div>
     <div class="navbar section">


### PR DESCRIPTION
## Description
Rendering html descriptions on Vendor pages inside <p> tag instead of <div> tag was causing nesting problems, which caused problems with filters sidebar. Changing the tag fixed it. Also implemented small style changes.

## How Has This Been Tested?
This was tested in our test environment that's integrated with Vendo's test env.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
